### PR TITLE
Challenge #3: Added an OrderBetweenDates List API view.

### DIFF
--- a/interview/order/urls.py
+++ b/interview/order/urls.py
@@ -1,10 +1,13 @@
 
 from django.urls import path
-from interview.order.views import OrderListCreateView, OrderTagListCreateView
-
+from interview.order.views import OrderListCreateView, OrderTagListCreateView, OrderBetweenStartEmbargoListView
 
 urlpatterns = [
     path('tags/', OrderTagListCreateView.as_view(), name='order-detail'),
+    path(
+        'between/<str:start>/<str:embargo>/',
+        OrderBetweenStartEmbargoListView.as_view(),
+        name='order-between-dates'),
     path('', OrderListCreateView.as_view(), name='order-list'),
 
 ]

--- a/interview/order/views.py
+++ b/interview/order/views.py
@@ -1,14 +1,50 @@
-from django.shortcuts import render
-from rest_framework import generics
+# standard library
+import datetime
 
+# third party
+from rest_framework import generics
+from rest_framework.response import Response
+from rest_framework.status import HTTP_400_BAD_REQUEST
+
+# local Django
 from interview.order.models import Order, OrderTag
 from interview.order.serializers import OrderSerializer, OrderTagSerializer
+
 
 # Create your views here.
 class OrderListCreateView(generics.ListCreateAPIView):
     queryset = Order.objects.all()
     serializer_class = OrderSerializer
-    
+
+
+class OrderBetweenStartEmbargoListView(generics.ListAPIView):
+    queryset = Order.objects.all()
+    serializer_class = OrderSerializer
+
+    def list(self, request, *args, **kwargs):
+        try:
+            return super().list(request, *args, **kwargs)
+        except ValueError:
+            return Response(
+                "Invalid `start_date` or `embargo_date` format. Should be YYYY-MM-DD",
+                status=HTTP_400_BAD_REQUEST
+            )
+
+    def validate_query_params(self):
+        try:
+            datetime.date.fromisoformat(self.kwargs.get('start', ''))
+            datetime.date.fromisoformat(self.kwargs.get('embargo', ''))
+        except ValueError:
+            raise ValueError("Incorrect date format, should be YYYY-MM-DD")
+
+    def filter_queryset(self, queryset):
+        self.validate_query_params()
+        start_date = self.kwargs.get('start')
+        embargo_date = self.kwargs.get('embargo')
+        queryset = self.get_queryset()
+
+        return queryset.filter(start_date__gte=start_date, embargo_date__lte=embargo_date)
+
 
 class OrderTagListCreateView(generics.ListCreateAPIView):
     queryset = OrderTag.objects.all()


### PR DESCRIPTION
### PR Type
[x] New Feature

### Approach
Added an OrderBetweenStartEmbargoListView view that returns `Order` instances whose `start` and `embargo` dates are within the used defined `start` and `embargo` dates, as following:
```
-------|------------------|-----------------------|------------------------|----------
user start date      order start date         order embargo date         user embargo date
```
Only orders that are completely within user-provided date range (as shown above) are going to be retrieved.